### PR TITLE
Standardizing that all endpoints end in a slash

### DIFF
--- a/src/omnipresence/urls.py
+++ b/src/omnipresence/urls.py
@@ -2,7 +2,7 @@ from . import views
 from django.urls import path, re_path
 
 urlpatterns  = [
-    path('', views.OmnipresenceView.as_view()),
+    path('/', views.OmnipresenceView.as_view()),
     re_path(r'update/(?P<pk>\d+)/', views.OmnipresenceUpdateView.as_view()),
     re_path(r'active/', views.OmnipresenceActiveView.as_view()),
     re_path(r'local/', views.OmnipresenceActiveView.as_view())


### PR DESCRIPTION
The `omnipresence` API contained a combined `POST`/`GET` route which didn't terminate with a slash. The API asks for a `/`. In order to _not_ ship a new container, I'm making the change at the API endpoint.